### PR TITLE
fixed number in string converted to variable of type number

### DIFF
--- a/code.js
+++ b/code.js
@@ -220,7 +220,7 @@ FirebaseApp_._buildRequest = function (method, base, path, data, optQueryParamet
     var parameters = [];
     for (var key in optQueryParameters) {
       if (key != "auth" && key != "shallow" && key != "print" && key != "limitToFirst" && key != "limitToLast") {
-        if (isNaN(optQueryParameters[key]) && typeof optQueryParameters[key] !== 'boolean') {
+        if (typeof optQueryParameters[key] === 'string') {
           optQueryParameters[key] = encodeURIComponent('"' + optQueryParameters[key] + '"');
         }
       }


### PR DESCRIPTION
It's important to do not change variable type while creating request. For example  when you change type string to number you'll get error when searching by key because firebase do not allow keys to be numbers, it allow only strings.